### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/anthropic/AbstractAnthropic.java
+++ b/src/main/java/io/kestra/plugin/anthropic/AbstractAnthropic.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -26,6 +27,7 @@ public abstract class AbstractAnthropic extends Task {
 
     @Schema(title = "Anthropic API Key")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> apiKey;
 
     @Schema(
@@ -33,6 +35,7 @@ public abstract class AbstractAnthropic extends Task {
         description = "Claude model name to invoke (e.g., claude-3-5-sonnet-20241022); must match an Anthropic model available to your API key."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> model;
 
     @Schema(
@@ -40,6 +43,7 @@ public abstract class AbstractAnthropic extends Task {
         description = "Maximum tokens Anthropic can generate; defaults to 1024 if unset."
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     protected Property<Long> maxTokens = Property.ofValue(1024L);
 
     @Schema(
@@ -53,12 +57,14 @@ public abstract class AbstractAnthropic extends Task {
         title = "Top P",
         description = "Nucleus sampling cap; 0.1 keeps only tokens in top 10% probability mass."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Double> topP;
 
     @Schema(
         title = "Top K",
         description = "Samples only from the top K tokens for each step; leave unset to let the model choose."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Integer> topK;
 
     protected void sendMetrics(RunContext runContext, Message message) {

--- a/src/main/java/io/kestra/plugin/anthropic/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/anthropic/ChatCompletion.java
@@ -28,6 +28,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -200,15 +201,18 @@ public class ChatCompletion extends AbstractAnthropic implements RunnableTask<Ch
 
     @Schema(title = "Messages", description = "Ordered chat turns rendered from properties; include at least one USER message.")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<ChatMessage>> messages;
 
     @Schema(title = "System prompt", description = "Optional system instructions applied to the whole conversation; rendered before sending to Claude.")
+    @PluginProperty(group = "advanced")
     private Property<String> system;
 
     @Schema(
         title = "Tools",
         description = "Optional tools Claude can invoke; each entry needs a unique name, an optional description, and an `input_schema` JSON Schema that defines the parameters the tool accepts."
     )
+    @PluginProperty(group = "destination")
     private Property<List<Tool>> tools;
 
     @Schema(


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712