### PR TITLE
Documentation review: plugin-anthropic

### DIFF
--- a/src/main/resources/doc/io.kestra.plugin.anthropic.md
+++ b/src/main/resources/doc/io.kestra.plugin.anthropic.md
@@ -8,4 +8,8 @@ Set `apiKey` to your Anthropic API key. Store it in a [secret](https://kestra.io
 
 ## Tasks
 
-`ChatCompletion` sends a prompt to a Claude model and returns the response. Set `modelId` to choose the model (e.g., `claude-opus-4-7`, `claude-sonnet-4-6`), and `maxTokens` to cap the response length. The task returns the completion text and token usage metrics as outputs for downstream steps.
+`ChatCompletion` sends a prompt to a Claude model and returns the response. Set `model` to choose the model (e.g., `claude-opus-4-7`, `claude-sonnet-4-6`) and `maxTokens` to cap the response length. It returns the completion text, any tool uses, the stop reason, and cache-token counts as outputs, and emits input/output/cache token-usage metrics.
+
+`ListModels` lists the Claude models available to your API key.
+
+The Files API tasks manage files for use with Claude, all via Anthropic's beta Files endpoint: `UploadFile` uploads a file from Kestra internal storage, `GetFile` retrieves a file's metadata, `ListFiles` lists stored files, and `DeleteFile` removes one.


### PR DESCRIPTION
## Documentation review: plugin-anthropic

Documentation-only pass over all 6 tasks (`ChatCompletion`, `ListModels`, and the four Files-API
tasks), the abstract bases, output POJOs, the plugin how-to doc, and metadata. Task inventory
cross-checked against the Kestra plugin registry (6 tasks, matches); model IDs verified as valid
current Anthropic models. No behavior, validation, or UI-layout changes.

1 file changed (the how-to doc).

### Fixed
- **Wrong property name:** the doc said "Set `modelId` to choose the model" — the property is
  `model` (there is no `modelId`). Corrected.
- **Completeness:** the Tasks section documented only `ChatCompletion`; added coverage of
  `ListModels` and the four Files-API tasks (`UploadFile`/`GetFile`/`ListFiles`/`DeleteFile`), and
  made the ChatCompletion outputs/metrics description precise.

### ⚠️ Follow-up for engineering (not changed here — code bugs)
1. **`ChatCompletion` sends `temperature` unconditionally** (default 1.0), plus `topP`/`topK` when
   set. The current Anthropic API rejects `temperature`/`top_p`/`top_k` with a 400 on Opus 4.7+/4.8,
   Sonnet 5, and Fable 5 — so `ChatCompletion` fails on those models, even though this plugin's doc
   suggests `claude-opus-4-7`. Fix: only send these parameters when the user explicitly set them
   (don't force the 1.0 temperature default onto every request).
2. **Non-chat tasks inherit a required `model` they never use.** `AbstractAnthropicFiles extends
   AbstractAnthropic`, so `ListModels` and all four Files tasks inherit `model` as `@NotNull`
   (plus unused `temperature`/`maxTokens`/`topP`/`topK`). Their examples all omit `model`, so as
   written they would fail `@NotNull` validation. Fix: give non-chat tasks a minimal base with just
   `apiKey`. (Their examples are left as-is — correct once the inheritance is fixed.)
3. Minor: the `ChatCompletion` class-description link `docs.anthropic.com/claude/reference/messages_post`
   is a legacy URL — worth updating to the current Anthropic API docs path.
